### PR TITLE
Introduce lint_report() test helper

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,3 +1,4 @@
 //! `bpflint` integration tests.
 
 mod lints;
+mod util;

--- a/tests/lints/probe-read.rs
+++ b/tests/lints/probe-read.rs
@@ -1,11 +1,8 @@
 //! Tests for the `probe-read` lint.
 
-use std::path::Path;
-
-use bpflint::lint;
-use bpflint::report_terminal;
-
 use pretty_assertions::assert_eq;
+
+use crate::util::lint_report;
 
 
 #[test]
@@ -21,14 +18,6 @@ int handle__sched_switch(u64 *ctx)
 }
 "#;
 
-    let mut report = Vec::new();
-    let () = lint(code.as_bytes())
-        .unwrap()
-        .into_iter()
-        .try_for_each(|m| report_terminal(&m, code.as_bytes(), Path::new("<stdin>"), &mut report))
-        .unwrap();
-    let report = String::from_utf8(report).unwrap();
-
     let expected = r#"warning: [probe-read] bpf_probe_read() is deprecated and replaced by bpf_probe_user() and bpf_probe_kernel(); refer to bpf-helpers(7)
   --> <stdin>:6:4
   | 
@@ -36,5 +25,5 @@ int handle__sched_switch(u64 *ctx)
   |     ^^^^^^^^^^^^^^
   | 
 "#;
-    assert_eq!(report, expected);
+    assert_eq!(lint_report(code), expected);
 }

--- a/tests/lints/unstable-attach-point.rs
+++ b/tests/lints/unstable-attach-point.rs
@@ -1,11 +1,8 @@
 //! Tests for the `unstable-attach-point` lint.
 
-use std::path::Path;
-
-use bpflint::lint;
-use bpflint::report_terminal;
-
 use pretty_assertions::assert_eq;
+
+use crate::util::lint_report;
 
 
 #[test]
@@ -16,14 +13,6 @@ int nanosleep(void *ctx) {
 }
 "#;
 
-    let mut report = Vec::new();
-    let () = lint(code.as_bytes())
-        .unwrap()
-        .into_iter()
-        .try_for_each(|m| report_terminal(&m, code.as_bytes(), Path::new("<stdin>"), &mut report))
-        .unwrap();
-    let report = String::from_utf8(report).unwrap();
-
     let expected = r#"warning: [unstable-attach-point] kprobe/kretprobe/fentry/fexit are conceptually unstable and prone to changes between kernel versions; consider more stable attach points such as tracepoints or LSM hooks, if available
   --> <stdin>:1:4
   | 
@@ -31,7 +20,7 @@ int nanosleep(void *ctx) {
   |     ^^^^^^^^^^^^^^^^^^^^^
   | 
 "#;
-    assert_eq!(report, expected);
+    assert_eq!(lint_report(code), expected);
 }
 
 
@@ -44,14 +33,6 @@ int BPF_KPROBE(kprobe__foobar, const struct cred *cred,
                struct user_namespace *targ_ns, int cap, int cap_opt) {
 "#;
 
-    let mut report = Vec::new();
-    let () = lint(code.as_bytes())
-        .unwrap()
-        .into_iter()
-        .try_for_each(|m| report_terminal(&m, code.as_bytes(), Path::new("<stdin>"), &mut report))
-        .unwrap();
-    let report = String::from_utf8(report).unwrap();
-
     let expected = r#"warning: [unstable-attach-point] kprobe/kretprobe/fentry/fexit are conceptually unstable and prone to changes between kernel versions; consider more stable attach points such as tracepoints or LSM hooks, if available
   --> <stdin>:1:4
   | 
@@ -59,5 +40,5 @@ int BPF_KPROBE(kprobe__foobar, const struct cred *cred,
   |     ^^^^^^^^^^^^^^^^^^^^
   | 
 "#;
-    assert_eq!(report, expected);
+    assert_eq!(lint_report(code), expected);
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,0 +1,23 @@
+//! Helpers for testing the linting functionality.
+
+use std::path::Path;
+
+use bpflint::lint;
+use bpflint::report_terminal;
+
+
+/// Lint `code` and report matches as a string created using
+/// [`report_terminal`].
+pub fn lint_report<C>(code: C) -> String
+where
+    C: AsRef<[u8]>,
+{
+    let mut report = Vec::new();
+    let () = lint(code.as_ref())
+        .unwrap()
+        .into_iter()
+        .try_for_each(|m| report_terminal(&m, code.as_ref(), Path::new("<stdin>"), &mut report))
+        .unwrap();
+    let report = String::from_utf8(report).unwrap();
+    report
+}


### PR DESCRIPTION
Our lint integration tests all use the same pattern for linting code and then checking the result of the "terminal report". Factor out a helper function,  `lint_report()`, that can be used to more easily create this report, deduplicating a bunch of code in the process.