### PR TITLE
Add workflow for updating tree-sitter-0.21 branch

### DIFF
--- a/.github/workflows/update-0.21.yml
+++ b/.github/workflows/update-0.21.yml
@@ -1,0 +1,25 @@
+name: Update tree-sitter-0.21 branch
+
+on:
+  push:
+    branches:
+    - main
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Merge with origin/main
+        shell: bash
+        run: |
+          git config --global user.name 'GitHub Actions Automation'
+          git config --global user.email 'ci_activity@noreply.github.com'
+          git checkout tree-sitter-0.21
+          git merge origin/main
+          git push origin HEAD:refs/heads/tree-sitter-0.21


### PR DESCRIPTION
For <reasons> we need to have a version of the library that works with tree-sitter version 0.21. To that end we have a branch, tree-sitter-0.21 that contains a patch set making this happen. However, rebasing said patch set is tedious and, contrary to "regular" workflows, we should not just rebase and throw away old commits but keep them around. This change adds a workflow that automates this process: whenever a change is pushed to main, it will merge these changes into the `tree-sitter-0.21` branch. As a result, we either get instant updates of said branch, ready for use, or an immediate notification that the merge did not happen successfully, indicating that the patch set needs to be adjusted.