### PR TITLE
Fix typo in `lints/` documentation

### DIFF
--- a/lints/README.md
+++ b/lints/README.md
@@ -5,15 +5,15 @@ such queries to find matches on source code and then reports those
 alongside location information and some other meta data.
 
 To better understand queries and the language that they are written in,
-please refer to the official chapter covering them:
-https://tree-sitter.github.io/tree-sitter/using-parsers/queries/index.html
+please refer to the official ["Queries" chapter][tree-sitter-queries]
+covering them.
 
-A lint is a regular query, with the added requirement that it contains a
+A lint is a regular Query, with the added requirement that it contains a
 `message` [directive][tree-sitter-directives] that explains to the user
 why the pattern being matched on is problematic. For an example please
 refer to the [`probe-read` lint][probe-read-message].
 
-A good introduction that to how a query interfaces with the underlying
+A good introduction that to how a Query interfaces with the underlying
 language grammar can be found in the ["Code Navigation Systems"
 chapter][tree-sitter-code-nav].
 
@@ -31,12 +31,12 @@ these BPF specific constructs.
 
 If the grammar still lacks support for a certain construct, it should be
 extended. As a general introduction to `tree-sitter` grammars, please
-refer to the ["Creating Parsers"][tree-sitter-parsers] chapter of the
+refer to the ["Creating Parsers" chapter][tree-sitter-parsers] of the
 `tree-sitter` documentation, as it details prerequisites and necessary
 background.
 
 With the preliminaries out of the way and assumed covered, the following
-workflow may be useful to quickly iterate in the BPF C parser:
+workflow may be useful to quickly iterate on the BPF C parser:
 - install the `tree-sitter` CLI; [instructions][tree-sitter-cli]
 - clone the `tree-sitter-bpf-c` repository
 ```sh
@@ -66,6 +66,7 @@ and requires no additional tools installed.
 [tree-sitter-bpf-c-grammar]: https://github.com/d-e-s-o/tree-sitter-bpf-c/blob/main/grammar.js
 [tree-sitter-cli]: https://github.com/tree-sitter/tree-sitter/tree/master/crates/cli
 [tree-sitter-parsers]: https://tree-sitter.github.io/tree-sitter/creating-parsers/index.html
+[tree-sitter-queries]: https://tree-sitter.github.io/tree-sitter/using-parsers/queries/index.html
 [tree-sitter-bpf-c-bpf.txt]: https://github.com/d-e-s-o/tree-sitter-bpf-c/blob/main/test/corpus/bpf.txt
 [tree-sitter-playground]: https://tree-sitter.github.io/tree-sitter/7-playground.html
 [probe-read-message]: https://github.com/d-e-s-o/bpflint/blob/b8716d24fb133de0371152705bd33a1c56f51bfe/lints/probe-read.scm#L8


### PR DESCRIPTION
Fix a type in the `lints/` documentation: "in the BPF C parser" -> "on the BPF C parser". While at it, also revisit a few other bits of the README, in hopes of improving them slightly.