### PR TITLE
Prevent `deploy` and `update-0.21` workflows from running on forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.repository == 'd-e-s-o/bpflint'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/update-0.21.yml
+++ b/.github/workflows/update-0.21.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   update:
+    if: github.repository == 'd-e-s-o/bpflint'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
There is no point in running the `deploy` and `update-0.21` workflows on forks, but that is what is happening by default right now. Make sure it no longer does.