### PR TITLE
cli: Add CHANGELOG entry for #18

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 - Added support for `@<file>` syntax for reading file list from `<file>`
+- Added warning when input file does not have `*.bpf.c` extension
 
 
 0.1.1

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,6 +6,7 @@ use std::env::var_os;
 use std::fs::read;
 use std::io;
 use std::io::Write as _;
+use std::path::Path;
 
 use anyhow::Context as _;
 use anyhow::Result;
@@ -18,14 +19,13 @@ use tracing_subscriber::FmtSubscriber;
 use tracing_subscriber::filter::EnvFilter;
 use tracing_subscriber::fmt::time::ChronoLocal;
 
+use bpflint::LintMatch;
+use bpflint::Point;
+use bpflint::Range;
 use bpflint::builtin_lints;
 use bpflint::lint;
 use bpflint::report_terminal;
 
-use bpflint::LintMatch;
-use bpflint::Point;
-use bpflint::Range;
-use std::path::Path;
 
 fn has_bpf_c_ext(path: &Path) -> bool {
     if let Some(file_name) = path.file_name() {
@@ -107,14 +107,14 @@ fn main() -> Result<()> {
     Ok(())
 }
 
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use std::path::Path;
 
-    /// tests whether `has_bpf_c_ext` correctly returns true
-    /// for *.bpf.c files else false
+    /// Test that [`has_bpf_c_ext`] works correctly for various
+    /// paths/extensions.
     #[test]
     fn test_has_bpf_c_ext() {
         assert!(has_bpf_c_ext(Path::new("file.bpf.c")));

--- a/src/report.rs
+++ b/src/report.rs
@@ -91,9 +91,10 @@ mod tests {
     use crate::Point;
     use crate::Range;
 
-    /// tests whether a file that has empty range still produces .c warn without line
+
+    /// Tests that a match with an empty range includes no code snippet.
     #[test]
-    fn no_bytes() {
+    fn empty_range_reporting() {
         let code = r#"int main(){}"#;
 
         let m = LintMatch {
@@ -114,7 +115,6 @@ mod tests {
 "#;
         assert_eq!(report, expected);
     }
-
 
     /// Check that our "terminal" reporting works as expected.
     #[test]


### PR DESCRIPTION
Add a CHANGELOG entry for pull request #18, which added logic for emitting a warning when an input file does not have the `*.bpf.c` extension. Also fix up a few minor stylistic issues to be more in-line with the existing style.