### PR TITLE
Use `indoc` crate for formatting code snippets and reports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ web-sys = { version = "0.3", features = ['console'], optional = true }
 
 [dev-dependencies]
 bpflint = { path = ".", features = ["debug"] }
+indoc = "2.0"
 pretty_assertions = "1.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/tests/lints/probe-read.rs
+++ b/tests/lints/probe-read.rs
@@ -1,5 +1,7 @@
 //! Tests for the `probe-read` lint.
 
+use indoc::indoc;
+
 use pretty_assertions::assert_eq;
 
 use crate::util::lint_report;
@@ -7,23 +9,24 @@ use crate::util::lint_report;
 
 #[test]
 fn basic() {
-    let code = r#"
-SEC("tp_btf/sched_switch")
-int handle__sched_switch(u64 *ctx)
-{
-    struct task_struct *prev = (struct task_struct *)ctx[1];
-    struct event event = {0};
-    bpf_probe_read(event.comm, TASK_COMM_LEN, prev->comm);
-    return 0;
-}
-"#;
+    let code = indoc! { r#"
+      SEC("tp_btf/sched_switch")
+      int handle__sched_switch(u64 *ctx)
+      {
+          struct task_struct *prev = (struct task_struct *)ctx[1];
+          struct event event = {0};
+          bpf_probe_read(event.comm, TASK_COMM_LEN, prev->comm);
+          return 0;
+      }
+    "# };
 
-    let expected = r#"warning: [probe-read] bpf_probe_read() is deprecated and replaced by bpf_probe_user() and bpf_probe_kernel(); refer to bpf-helpers(7)
-  --> <stdin>:6:4
-  | 
-6 |     bpf_probe_read(event.comm, TASK_COMM_LEN, prev->comm);
-  |     ^^^^^^^^^^^^^^
-  | 
-"#;
+    let expected = indoc! { r#"
+      warning: [probe-read] bpf_probe_read() is deprecated and replaced by bpf_probe_user() and bpf_probe_kernel(); refer to bpf-helpers(7)
+        --> <stdin>:5:4
+        | 
+      5 |     bpf_probe_read(event.comm, TASK_COMM_LEN, prev->comm);
+        |     ^^^^^^^^^^^^^^
+        | 
+    "# };
     assert_eq!(lint_report(code), expected);
 }

--- a/tests/lints/unstable-attach-point.rs
+++ b/tests/lints/unstable-attach-point.rs
@@ -1,5 +1,7 @@
 //! Tests for the `unstable-attach-point` lint.
 
+use indoc::indoc;
+
 use pretty_assertions::assert_eq;
 
 use crate::util::lint_report;
@@ -7,38 +9,40 @@ use crate::util::lint_report;
 
 #[test]
 fn basic() {
-    let code = r#"
-SEC("fentry/do_nanosleep")
-int nanosleep(void *ctx) {
-}
-"#;
+    let code = indoc! { r#"
+      SEC("fentry/do_nanosleep")
+      int nanosleep(void *ctx) {
+      }
+    "# };
 
-    let expected = r#"warning: [unstable-attach-point] kprobe/kretprobe/fentry/fexit are conceptually unstable and prone to changes between kernel versions; consider more stable attach points such as tracepoints or LSM hooks, if available
-  --> <stdin>:1:4
-  | 
-1 | SEC("fentry/do_nanosleep")
-  |     ^^^^^^^^^^^^^^^^^^^^^
-  | 
-"#;
+    let expected = indoc! { r#"
+      warning: [unstable-attach-point] kprobe/kretprobe/fentry/fexit are conceptually unstable and prone to changes between kernel versions; consider more stable attach points such as tracepoints or LSM hooks, if available
+        --> <stdin>:0:4
+        | 
+      0 | SEC("fentry/do_nanosleep")
+        |     ^^^^^^^^^^^^^^^^^^^^^
+        | 
+    "# };
     assert_eq!(lint_report(code), expected);
 }
 
 
 #[test]
 fn basic2() {
-    let code = r#"
-SEC("kprobe/cap_capable")
+    let code = indoc! { r#"
+      SEC("kprobe/cap_capable")
 
-int BPF_KPROBE(kprobe__foobar, const struct cred *cred,
-               struct user_namespace *targ_ns, int cap, int cap_opt) {
-"#;
+      int BPF_KPROBE(kprobe__foobar, const struct cred *cred,
+                     struct user_namespace *targ_ns, int cap, int cap_opt) {
+    "# };
 
-    let expected = r#"warning: [unstable-attach-point] kprobe/kretprobe/fentry/fexit are conceptually unstable and prone to changes between kernel versions; consider more stable attach points such as tracepoints or LSM hooks, if available
-  --> <stdin>:1:4
-  | 
-1 | SEC("kprobe/cap_capable")
-  |     ^^^^^^^^^^^^^^^^^^^^
-  | 
-"#;
+    let expected = indoc! { r#"
+      warning: [unstable-attach-point] kprobe/kretprobe/fentry/fexit are conceptually unstable and prone to changes between kernel versions; consider more stable attach points such as tracepoints or LSM hooks, if available
+        --> <stdin>:0:4
+        | 
+      0 | SEC("kprobe/cap_capable")
+        |     ^^^^^^^^^^^^^^^^^^^^
+        | 
+    "# };
     assert_eq!(lint_report(code), expected);
 }


### PR DESCRIPTION
Use the `indoc` crate for formatting code snippets and expected reports. Doing so makes things ever so slightly more readable, as we are able to indent said snippets like the surrounding code and don't have to worry as much about spurious newlines.