### PR TITLE
New query to test bpf grammar change

### DIFF
--- a/lints/untyped-map-member.scm
+++ b/lints/untyped-map-member.scm
@@ -1,0 +1,8 @@
+
+(preproc_call_expression
+  macro_name: (identifier) @name (#eq? @name "__uint")
+  (identifier)
+  (sizeof_expression
+    (_)*)
+    (#set! "message" "__uint(a, sizeof(b)) does not contain potentially relevant type information, consider using __type(a, b) instead")
+)


### PR DESCRIPTION
New query was added to/lint so we can lints in action from the bpf map grammar changes