### PR TITLE
Added new lint query in /lints for bpf map grammar change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ wasm-bindgen-cli-support = { version = "0.2", default-features = false }
 [dependencies]
 anyhow = "1.0"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-tree-sitter-bpf-c = "0.2.1"
+tree-sitter-bpf-c = "0.2.2"
 web-sys = { version = "0.3", features = ['console'], optional = true }
 
 [dev-dependencies]

--- a/lints/unstable-attach-point.scm
+++ b/lints/unstable-attach-point.scm
@@ -1,7 +1,7 @@
 (function_definition
     (sec_specifier
-      value: (string_literal) @probe
-      (#match? @probe "^\"(k(ret)?probe|f(entry|exit))/[^\"\\n]+\"$")
+        value: (string_literal) @probe
+        (#match? @probe "^\"(k(ret)?probe|f(entry|exit))/[^\"\\n]+\"$")
     )
     (#set! "message" "kprobe/kretprobe/fentry/fexit are conceptually unstable and prone to changes between kernel versions; consider more stable attach points such as tracepoints or LSM hooks, if available")
 )

--- a/lints/untyped-map-member.scm
+++ b/lints/untyped-map-member.scm
@@ -1,0 +1,6 @@
+(preproc_call_expression
+    macro_name: (identifier) @__name (#eq? @__name "__uint")
+    arg1: (identifier) @__arg1 (#any-of? @__arg1 "key_size" "value_size")
+    (sizeof_expression)
+    (#set! "message" "__uint(a, sizeof(b)) does not contain potentially relevant type information, consider using __type(a, b) instead")
+) @call

--- a/tests/lints/mod.rs
+++ b/tests/lints/mod.rs
@@ -9,3 +9,5 @@ mod validate;
 mod probe_read;
 #[path = "unstable-attach-point.rs"]
 mod unstable_attach_point;
+#[path = "untyped-map-member.rs"]
+mod untyped_map_member;

--- a/tests/lints/untyped-map-member.rs
+++ b/tests/lints/untyped-map-member.rs
@@ -1,0 +1,28 @@
+//! Tests for the `untyped-map-member` lint.
+
+use indoc::indoc;
+
+use pretty_assertions::assert_eq;
+
+use crate::util::lint_report;
+
+
+#[test]
+fn basic_sizeof() {
+    let code = indoc! { r#"
+      struct {
+          int a;
+          __uint(key_size, sizeof(b));
+      } name;
+    "# };
+
+    let expected = indoc! { r#"
+      warning: [untyped-map-member] __uint(a, sizeof(b)) does not contain potentially relevant type information, consider using __type(a, b) instead
+        --> <stdin>:2:4
+        | 
+      2 |     __uint(key_size, sizeof(b));
+        |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        | 
+    "# };
+    assert_eq!(lint_report(code), expected);
+}


### PR DESCRIPTION
New grammar was added to the project to support bpf map macros. This is a new lint that will be possible due to the grammar change.