### PR TITLE
use ring buf as opposed to perf buf lint

### DIFF
--- a/lints/perf-buff-map.scm
+++ b/lints/perf-buff-map.scm
@@ -1,0 +1,6 @@
+(preproc_call_expression
+    macro_name: (identifier) @__name (#eq? @__name "__uint")
+    arg1: (identifier) @__arg1 (#eq? @__arg1 "type")
+    arg2: (identifier) @__arg2 (#eq? @__arg2 "BPF_MAP_TYPE_PERF_EVENT_ARRAY")
+    (#set! "message" "Using ring buffers is preferred over perf buffers")
+) @call

--- a/tests/lints/mod.rs
+++ b/tests/lints/mod.rs
@@ -11,3 +11,5 @@ mod probe_read;
 mod unstable_attach_point;
 #[path = "untyped-map-member.rs"]
 mod untyped_map_member;
+#[path = "perf-buff-map.rs"]
+mod perf_buff_map;

--- a/tests/lints/perf-buff-map.rs
+++ b/tests/lints/perf-buff-map.rs
@@ -1,0 +1,28 @@
+//! Tests for the `perf-buff-map` lint.
+
+use indoc::indoc;
+
+use pretty_assertions::assert_eq;
+
+use crate::util::lint_report;
+
+
+#[test]
+fn perf_map_usage() {
+    let code = indoc! { r#"
+      struct {
+        int a;
+        __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+      } name;
+    "# };
+
+    let expected = indoc! { r#"
+      warning: [perf-buff-map] Using ring buffers is preferred over perf buffers
+        --> <stdin>:2:2
+        | 
+      2 |   __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        | 
+    "# };
+    assert_eq!(lint_report(code), expected);
+}


### PR DESCRIPTION
Ring buff usage is generally preferred. A simple query was added to lints/ which looks for nodes associated with `__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY)`. A test was added to tests/lints to confirm correct behavior.