### PR TITLE
cli: Add USAGE.md containing output of --help option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,18 @@ jobs:
     - uses: actions/checkout@v5
     - name: Test
       run: cargo test --workspace
+  cli-usage:
+    name: CLI Usage
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - run: |
+        echo '```' > cli/USAGE.md
+        cargo run --package bpflinter -- --help >> cli/USAGE.md
+        echo '```' >> cli/USAGE.md
+    - name: Check that usage info is up-to-date
+      run: git diff --exit-code ||
+             (echo "!!!! CHECKED IN USAGE.md IS OUTDATED !!!!" && false)
   clippy:
     name: Lint with clippy
     runs-on: ubuntu-latest

--- a/cli/README.md
+++ b/cli/README.md
@@ -48,8 +48,8 @@ warning: [probe-read] bpf_probe_read() is deprecated and replaced by bpf_probe_u
    |
 ```
 
-For additional information, please refer to the program's help text
-(`bpflinter --help`).
+For additional information, please refer to [USAGE.md](USAGE.md) or the
+program's help text (`bpflinter --help`).
 
 [cli-releases]: https://github.com/d-e-s-o/bpflint/releases
 [bpflint]: https://github.com/d-e-s-o/bpflint

--- a/cli/USAGE.md
+++ b/cli/USAGE.md
@@ -1,0 +1,24 @@
+```
+A command line interface for bpflint
+
+Usage: bpflinter [OPTIONS] <[@]SRCS>...
+
+Arguments:
+  <[@]SRCS>...
+          The BPF C source files to lint.
+          
+          Use '@file' syntax to include a (newline separated) list of files from 'file'.
+
+Options:
+      --print-lints
+          Print a list of available lints
+
+  -v, --verbose...
+          Increase verbosity (can be supplied multiple times)
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+```

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -30,13 +30,14 @@ fn parse_files(s: &str) -> Result<Vec<PathBuf>> {
 }
 
 
-/// A command line interface for `bpflint`.
+/// A command line interface for bpflint.
 #[derive(Debug, Parser)]
 #[command(version = env!("VERSION"))]
 pub struct Args {
     /// The BPF C source files to lint.
     ///
-    /// Use '@file' syntax to include a file list contained in 'file'.
+    /// Use '@file' syntax to include a (newline separated) list of
+    /// files from 'file'.
     #[arg(required = true, value_name = "[@]SRCS", value_parser = parse_files)]
     pub srcs: Vec<Vec<PathBuf>>,
     /// Print a list of available lints.


### PR DESCRIPTION
Introduce the `USAGE.md` file containing the output of the `--help` option. Having this summary of usage information available this way makes it easier to look up information pertaining the invocation without having to compile the program. Also add a CI workflow ensuring that this data is up-to-date.