### PR TITLE
Adding grep-style context parameters (-A, -B, -C) for enhanced error reporting

### DIFF
--- a/cli/USAGE.md
+++ b/cli/USAGE.md
@@ -16,6 +16,15 @@ Options:
   -v, --verbose...
           Increase verbosity (can be supplied multiple times)
 
+  -B, --before <BEFORE>
+          Number of lines to show before the error line
+
+  -A, --after <AFTER>
+          Number of lines to show after the error line
+
+  -C, --context <CONTEXT>
+          Number of lines to show before and after the error line
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -29,6 +29,31 @@ fn parse_files(s: &str) -> Result<Vec<PathBuf>> {
     }
 }
 
+/// Parse a context line count for CLI arguments, with enhanced error reporting.
+///
+/// This function is used as a value parser for line count arguments (e.g. --before, --after, --context)
+/// It converts a string input to a u8 value while providing clear error messages
+/// when the input is invalid.
+///
+/// # Arguments
+/// * `s` - Raw input string, expected to be a number from 0 to 255 inclusive.
+///
+/// # Returns
+/// * `Ok(u8)` - The parsed line count if valid
+/// * `Err(anyhow::Error)` - If the input cannot be parsed as u8 or is out of range
+///
+/// # Examples
+/// ```
+/// assert_eq!(parse_context_line_count("5").unwrap(), 5);
+/// assert!(parse_context_line_count("256").is_err());
+/// assert!(parse_context_line_count("abc").is_err());
+/// ```
+fn parse_context_line_count(s: &str) -> Result<u8> {
+    let line_count = s
+        .parse::<u8>()
+        .with_context(|| format!("invalid context line count: '{s}' (must be 0-255)"))?;
+    Ok(line_count)
+}
 
 /// A command line interface for bpflint.
 #[derive(Debug, Parser)]
@@ -46,8 +71,38 @@ pub struct Args {
     /// Increase verbosity (can be supplied multiple times).
     #[arg(short = 'v', long = "verbose", global = true, action = ArgAction::Count)]
     pub verbosity: u8,
+    /// Number of lines to show before the error line.
+    #[arg(short = 'B', long = "before", value_parser = parse_context_line_count)]
+    pub before: Option<u8>,
+    /// Number of lines to show after the error line.
+    #[arg(short = 'A', long = "after", value_parser = parse_context_line_count)]
+    pub after: Option<u8>,
+    /// Number of lines to show before and after the error line.
+    #[arg(short = 'C', long = "context", value_parser = parse_context_line_count, conflicts_with_all = ["before", "after"])]
+    pub context: Option<u8>,
 }
 
+impl Args {
+    /// Calculate the effective context configuration.
+    pub fn additional_options(&self) -> bpflint::Opts {
+        let (before, after) = if let Some(context) = self.context {
+            // -C sets both before and after to the same value
+            (context, context)
+        } else {
+            // Use -A and -B values directly (they can be combined)
+            (self.before.unwrap_or(0), self.after.unwrap_or(0))
+        };
+
+        // If both are 0 (default), use None
+        if before == 0 && after == 0 {
+            bpflint::Opts::default()
+        } else {
+            bpflint::Opts {
+                extra_lines: Some((before, after)),
+            }
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -58,21 +113,20 @@ mod tests {
 
     use tempfile::NamedTempFile;
 
+    fn try_parse<I, T>(srcs: I) -> Result<Args, clap::Error>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<OsString> + Clone,
+    {
+        let args = [OsString::from("executable")]
+            .into_iter()
+            .chain(srcs.into_iter().map(T::into));
+        Args::try_parse_from(args)
+    }
 
     /// Make sure that we can recognize file list inputs as expected.
     #[test]
     fn source_file_parsing() {
-        fn try_parse<I, T>(srcs: I) -> Result<Args, clap::Error>
-        where
-            I: IntoIterator<Item = T>,
-            T: Into<OsString> + Clone,
-        {
-            let args = [OsString::from("executable")]
-                .into_iter()
-                .chain(srcs.into_iter().map(T::into));
-            Args::try_parse_from(args)
-        }
-
         // Single file by path.
         let srcs = ["foobar"];
         let args = try_parse(srcs).unwrap();
@@ -109,5 +163,58 @@ mod tests {
                 vec![PathBuf::from("1st"), PathBuf::from("2nd")]
             ]
         );
+    }
+
+    /// Test context argument parsing and effective values.
+    #[test]
+    fn context_argument_parsing() {
+        // Default values
+        let args = try_parse(["test.c"]).unwrap();
+        let opts = args.additional_options();
+        assert_eq!(opts.extra_lines, None);
+
+        // -B 3 -A 4 (can be combined)
+        let args = try_parse(["test.c", "-B", "3", "-A", "4"]).unwrap();
+        let opts = args.additional_options();
+        assert_eq!(opts.extra_lines, Some((3, 4)));
+
+        // -C 4 (sets both before and after to 4)
+        let args = try_parse(["test.c", "-C", "4"]).unwrap();
+        let opts = args.additional_options();
+        assert_eq!(opts.extra_lines, Some((4, 4)));
+    }
+
+    /// Test that -C cannot be combined with -A or -B using clap groups.
+    #[test]
+    fn context_conflict_validation() {
+        // -C with -B should fail parsing (clap will reject it)
+        assert!(try_parse(["test.c", "-C", "3", "-B", "2"]).is_err());
+
+        // -C with -A should fail parsing (clap will reject it)
+        assert!(try_parse(["test.c", "-C", "3", "-A", "4"]).is_err());
+
+        // -C with both -A and -B should fail parsing (clap will reject it)
+        assert!(try_parse(["test.c", "-C", "3", "-B", "2", "-A", "4"]).is_err());
+
+        // -A and -B without -C should pass parsing
+        assert!(try_parse(["test.c", "-B", "2", "-A", "4"]).is_ok());
+    }
+
+    /// Test `parse_context_line_count` function directly.
+    #[test]
+    fn parse_context_line_count_validation() {
+        // Valid values
+        assert_eq!(parse_context_line_count("0").unwrap(), 0);
+        assert_eq!(parse_context_line_count("1").unwrap(), 1);
+        assert_eq!(parse_context_line_count("255").unwrap(), 255);
+
+        // Invalid values - out of range
+        assert!(parse_context_line_count("256").is_err());
+        assert!(parse_context_line_count("1000").is_err());
+        assert!(parse_context_line_count("-1").is_err());
+
+        // Invalid values - not numbers
+        assert!(parse_context_line_count("abc").is_err());
+        assert!(parse_context_line_count("").is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,8 +60,9 @@ pub use crate::lint::LintMatch;
 pub use crate::lint::LintMeta;
 pub use crate::lint::builtin_lints;
 pub use crate::lint::lint;
+pub use crate::report::Opts;
 pub use crate::report::report_terminal;
-
+pub use crate::report::report_terminal_opts;
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {

--- a/src/report.rs
+++ b/src/report.rs
@@ -6,6 +6,109 @@ use anyhow::Result;
 use crate::LintMatch;
 use crate::lines::Lines;
 
+/// Configuration options for terminal reporting.
+#[derive(Default, Clone, Debug)]
+pub struct Opts {
+    /// Extra context lines: (`lines_before`, `lines_after`).
+    pub extra_lines: Option<(u8, u8)>,
+}
+
+impl Opts {
+    /// Get the number of lines to show before the lint match.
+    pub fn lines_before(&self) -> usize {
+        match self.extra_lines {
+            None => 0,
+            Some((before, _)) => usize::from(before),
+        }
+    }
+
+    /// Get the number of lines to show after the error.
+    pub fn lines_after(&self) -> usize {
+        match self.extra_lines {
+            None => 0,
+            Some((_, after)) => usize::from(after),
+        }
+    }
+}
+
+/// Find the byte position of the start of a specific line number (0-indexed)
+fn find_line_start_by_row(code: &[u8], target_row: usize) -> usize {
+    if target_row == 0 {
+        return 0;
+    }
+
+    let mut current_row = 0;
+    for (idx, &byte) in code.iter().enumerate() {
+        if byte == b'\n' {
+            current_row += 1;
+            if current_row == target_row {
+                return idx + 1;
+            }
+        }
+    }
+
+    // If we didn't find enough newlines, return the start of the code
+    0
+}
+
+/// Find the total number of lines in the code
+fn count_lines(code: &[u8]) -> usize {
+    if code.is_empty() {
+        return 0;
+    }
+    code.iter().filter(|&&b| b == b'\n').count() + 1
+}
+
+/// Find context lines before the error line
+fn find_context_lines_before(code: &[u8], start_row: usize, count: usize) -> Vec<(usize, usize)> {
+    if start_row == 0 || count == 0 {
+        return Vec::new();
+    }
+
+    let mut context_lines = Vec::new();
+    let start_search = start_row.saturating_sub(count);
+
+    for row in start_search..start_row {
+        let line_start = find_line_start_by_row(code, row);
+        context_lines.push((row, line_start));
+    }
+
+    context_lines
+}
+
+/// Find context lines after the error line (including empty lines)
+fn find_context_lines_after(code: &[u8], end_row: usize, count: usize) -> Vec<(usize, usize)> {
+    let total_lines = count_lines(code);
+    if end_row + 1 >= total_lines || count == 0 {
+        return Vec::new();
+    }
+
+    let mut context_lines = Vec::new();
+    let end_search = (end_row + 1 + count).min(total_lines);
+
+    for row in (end_row + 1)..end_search {
+        let line_start = find_line_start_by_row(code, row);
+        context_lines.push((row, line_start));
+    }
+
+    context_lines
+}
+
+/// Display context lines to the writer.
+fn display_context_lines(
+    context_lines: &[(usize, usize)],
+    code: &[u8],
+    writer: &mut dyn io::Write,
+) -> Result<()> {
+    for (context_row, context_byte) in context_lines {
+        let mut lines = Lines::new(code, *context_byte);
+        if let Some(line) = lines.next() {
+            let lprefix = format!("{context_row} | ");
+            writeln!(writer, "{lprefix}{}", String::from_utf8_lossy(line))?;
+        }
+    }
+    Ok(())
+}
 
 /// Report a lint match in terminal style.
 ///
@@ -33,6 +136,41 @@ pub fn report_terminal(
     path: &Path,
     writer: &mut dyn io::Write,
 ) -> Result<()> {
+    report_terminal_opts(r#match, code, path, writer, &Opts::default())
+}
+
+/// Report a lint match in terminal style with extra lines for context as configured.
+///
+/// - `match` is the match to create a report for
+/// - `code` is the source code in question, as passed to
+///   [`lint`][crate::lint()]
+/// - `path` should be the path to the file to which `code` corresponds
+///   and is used to enhance the generated report
+/// - `writer` is a reference to a [`io::Write`] to which to write the
+///   report
+/// - `opts` specifies the reporting options including context lines
+///
+/// # Example
+/// ```text
+/// warning: [probe-read] bpf_probe_read() is deprecated and replaced by
+///          bpf_probe_user() and bpf_probe_kernel(); refer to bpf-helpers(7)
+///   --> example.bpf.c:43:24
+///    |
+/// 41 |     struct task_struct *prev = (struct task_struct *)ctx[1];
+/// 42 |     struct event event = {0};
+/// 43 |     bpf_probe_read(event.comm, TASK_COMM_LEN, prev->comm);
+///    |     ^^^^^^^^^^^^^^
+/// 44 |     return 0;
+/// 45 | }
+///    |
+/// ```
+pub fn report_terminal_opts(
+    r#match: &LintMatch,
+    code: &[u8],
+    path: &Path,
+    writer: &mut dyn io::Write,
+    opts: &Opts,
+) -> Result<()> {
     let LintMatch {
         lint_name,
         message,
@@ -47,23 +185,48 @@ pub fn report_terminal(
     writeln!(writer, "  --> {}:{start_row}:{start_col}", path.display())?;
 
     if range.bytes.is_empty() {
-        return Ok(())
+        return Ok(());
     }
 
-    // SANITY: It would be a tree-sitter bug the range does not
-    //         map to a valid code location.
-    let mut lines = Lines::new(code, range.bytes.start);
-    // Use the end row here, as it's the largest number, so we end up
-    // with a consistent indentation.
-    let prefix = format!("{:width$} | ", "", width = end_row.to_string().len());
+    // Find context lines
+    let context_lines_before = find_context_lines_before(code, start_row, opts.lines_before());
+    let context_lines_after = find_context_lines_after(code, end_row, opts.lines_after());
+
+    // Calculate the maximum row number for consistent indentation
+    let max_row = context_lines_after
+        .last()
+        .map(|(row, _)| *row)
+        .unwrap_or(end_row);
+    let prefix = format!("{:width$} | ", "", width = max_row.to_string().len());
     writeln!(writer, "{prefix}")?;
 
-    if start_row == end_row {
-        let lprefix = format!("{start_row} | ");
-        // SANITY: `Lines` will always report at least a single
-        //          line.
-        let line = lines.next().unwrap();
-        writeln!(writer, "{lprefix}{}", String::from_utf8_lossy(line))?;
+    // Show context lines before (if any)
+    display_context_lines(&context_lines_before, code, writer)?;
+
+    // Show the error lines
+    let mut lines = Lines::new(code, range.bytes.start);
+    let is_multiline = start_row != end_row;
+
+    for (idx, row) in (start_row..=end_row).enumerate() {
+        let lprefix = format!("{row} | ");
+        if let Some(line) = lines.next() {
+            let mut c = "";
+            if is_multiline {
+                c = if idx == 0 { " / " } else { " | " };
+            }
+
+            writeln!(writer, "{lprefix}{c}{}", String::from_utf8_lossy(line))?;
+        } else if idx == 0 {
+            // SANITY: It would be a tree-sitter bug IF the range does not
+            //         map to a valid code location.
+            panic!("Expected error line");
+        }
+    }
+
+    // Show the appropriate underline
+    if is_multiline {
+        writeln!(writer, "{prefix} |{:_<width$}^", "", width = end_col)?;
+    } else {
         writeln!(
             writer,
             "{prefix}{:indent$}{:^<width$}",
@@ -72,18 +235,10 @@ pub fn report_terminal(
             indent = start_col,
             width = end_col.saturating_sub(start_col)
         )?;
-    } else {
-        for (idx, row) in (start_row..=end_row).enumerate() {
-            let lprefix = format!("{row} | ");
-            let c = if idx == 0 { "/" } else { "|" };
-            // SANITY: There will always be another line available,
-            //         given that we are within the bounds of `range`,
-            //         which maps to source code lines.
-            let line = lines.next().unwrap();
-            writeln!(writer, "{lprefix} {c} {}", String::from_utf8_lossy(line))?;
-        }
-        writeln!(writer, "{prefix} |{:_<width$}^", "", width = end_col)?;
     }
+
+    // Show context lines after (if any)
+    display_context_lines(&context_lines_after, code, writer)?;
 
     writeln!(writer, "{prefix}")?;
     Ok(())
@@ -155,6 +310,7 @@ mod tests {
         let mut report = Vec::new();
         let () = report_terminal(&m, code.as_bytes(), Path::new("<stdin>"), &mut report).unwrap();
         let report = String::from_utf8(report).unwrap();
+
         let expected = indoc! { r#"
           warning: [probe-read] bpf_probe_read() is deprecated
             --> <stdin>:2:4
@@ -195,6 +351,7 @@ mod tests {
         let mut report = Vec::new();
         let () = report_terminal(&m, code.as_bytes(), Path::new("<stdin>"), &mut report).unwrap();
         let report = String::from_utf8(report).unwrap();
+
         let expected = indoc! { r#"
           warning: [probe-read] bpf_probe_read() is deprecated
             --> <stdin>:6:4
@@ -229,14 +386,322 @@ mod tests {
         let mut report = Vec::new();
         let () = report_terminal(&m, code.as_bytes(), Path::new("<stdin>"), &mut report).unwrap();
         let report = String::from_utf8(report).unwrap();
+
         let expected = indoc! { r#"
-          warning: [unstable-attach-point] kprobe/kretprobe/fentry/fexit are unstable
-            --> <stdin>:0:4
-            | 
-          0 | SEC("kprobe/test")
-            |     ^^^^^^^^^^^^^
-            | 
+            warning: [unstable-attach-point] kprobe/kretprobe/fentry/fexit are unstable
+              --> <stdin>:0:4
+              | 
+            0 | SEC("kprobe/test")
+              |     ^^^^^^^^^^^^^
+              | 
         "# };
         assert_eq!(report, expected);
+    }
+
+    /// Test that `report_terminal_opts` with `Opts::default()` behaves
+    /// identically to `report_terminal`.
+    #[test]
+    fn report_terminal_opts_none_context() {
+        let code = indoc! { r#"
+          SEC("tp_btf/sched_switch")
+          int handle__sched_switch(u64 *ctx)
+          {
+              struct task_struct *prev = (struct task_struct *)ctx[1];
+              struct event event = {0};
+              bpf_probe_read(event.comm, TASK_COMM_LEN, prev->comm);
+              return 0;
+          }
+        "# };
+
+        let m = LintMatch {
+            lint_name: "probe-read".to_string(),
+            message: "bpf_probe_read() is deprecated".to_string(),
+            range: Range {
+                bytes: 160..174,
+                start_point: Point { row: 5, col: 4 },
+                end_point: Point { row: 5, col: 18 },
+            },
+        };
+
+        let mut report_old = Vec::new();
+        let mut report_new = Vec::new();
+
+        let () =
+            report_terminal(&m, code.as_bytes(), Path::new("<stdin>"), &mut report_old).unwrap();
+        let () = report_terminal_opts(
+            &m,
+            code.as_bytes(),
+            Path::new("<stdin>"),
+            &mut report_new,
+            &Opts::default(),
+        )
+        .unwrap();
+
+        assert_eq!(report_old, report_new);
+    }
+
+    /// Test `report_terminal_opts` with extra context lines.
+    #[test]
+    fn report_terminal_opts_with_context() {
+        let code = indoc! { r#"
+          SEC("tp_btf/sched_switch")
+          int handle__sched_switch(u64 *ctx)
+          {
+              struct task_struct *prev = (struct task_struct *)ctx[1];
+              struct event event = {0};
+              bpf_probe_read(event.comm, TASK_COMM_LEN, prev->comm);
+              return 0;
+          }
+        "# };
+
+        let m = LintMatch {
+            lint_name: "probe-read".to_string(),
+            message: "bpf_probe_read() is deprecated".to_string(),
+            range: Range {
+                bytes: 160..174,
+                start_point: Point { row: 5, col: 4 },
+                end_point: Point { row: 5, col: 18 },
+            },
+        };
+        let mut report = Vec::new();
+        let () = report_terminal_opts(
+            &m,
+            code.as_bytes(),
+            Path::new("<stdin>"),
+            &mut report,
+            &Opts {
+                extra_lines: Some((2, 1)),
+            },
+        )
+        .unwrap();
+        let report = String::from_utf8(report).unwrap();
+
+        let expected = indoc! { r#"
+            warning: [probe-read] bpf_probe_read() is deprecated
+              --> <stdin>:5:4
+              | 
+            3 |     struct task_struct *prev = (struct task_struct *)ctx[1];
+            4 |     struct event event = {0};
+            5 |     bpf_probe_read(event.comm, TASK_COMM_LEN, prev->comm);
+              |     ^^^^^^^^^^^^^^
+            6 |     return 0;
+              | 
+        "# };
+        assert_eq!(report, expected);
+    }
+
+    /// Test context lines with multi-line matches.
+    #[test]
+    fn report_terminal_opts_multiline_with_context() {
+        let code = indoc! { r#"
+          SEC("tp_btf/sched_switch")
+          int handle__sched_switch(u64 *ctx) {
+              bpf_probe_read(
+                event.comm,
+                TASK_COMM_LEN,
+                prev->comm);
+              return 0;
+          }
+        "# };
+
+        let m = LintMatch {
+            lint_name: "probe-read".to_string(),
+            message: "bpf_probe_read() is deprecated".to_string(),
+            range: Range {
+                bytes: 68..140,
+                start_point: Point { row: 2, col: 4 },
+                end_point: Point { row: 5, col: 17 },
+            },
+        };
+        let mut report = Vec::new();
+        let () = report_terminal_opts(
+            &m,
+            code.as_bytes(),
+            Path::new("<stdin>"),
+            &mut report,
+            &Opts {
+                extra_lines: Some((1, 1)),
+            },
+        )
+        .unwrap();
+        let report = String::from_utf8(report).unwrap();
+
+        let expected = indoc! { r#"
+            warning: [probe-read] bpf_probe_read() is deprecated
+              --> <stdin>:2:4
+              | 
+            1 | int handle__sched_switch(u64 *ctx) {
+            2 |  /     bpf_probe_read(
+            3 |  |       event.comm,
+            4 |  |       TASK_COMM_LEN,
+            5 |  |       prev->comm);
+              |  |_________________^
+            6 |     return 0;
+              | 
+        "# };
+        assert_eq!(report, expected);
+    }
+
+    /// Test context lines when there aren't enough lines before the error.
+    #[test]
+    fn report_terminal_opts_insufficient_context_before() {
+        let code = indoc! { r#"
+          SEC("kprobe/test")
+          int handle__test(void)
+          {
+          }
+        "# };
+
+        let m = LintMatch {
+            lint_name: "unstable-attach-point".to_string(),
+            message: "kprobe/kretprobe/fentry/fexit are unstable".to_string(),
+            range: Range {
+                bytes: 4..17,
+                start_point: Point { row: 0, col: 4 },
+                end_point: Point { row: 0, col: 17 },
+            },
+        };
+        let mut report = Vec::new();
+        let () = report_terminal_opts(
+            &m,
+            code.as_bytes(),
+            Path::new("<stdin>"),
+            &mut report,
+            &Opts {
+                extra_lines: Some((5, 2)),
+            },
+        )
+        .unwrap();
+        let report = String::from_utf8(report).unwrap();
+
+        let expected = indoc! { r#"
+            warning: [unstable-attach-point] kprobe/kretprobe/fentry/fexit are unstable
+              --> <stdin>:0:4
+              | 
+            0 | SEC("kprobe/test")
+              |     ^^^^^^^^^^^^^
+            1 | int handle__test(void)
+            2 | {
+              | 
+        "# };
+        assert_eq!(report, expected);
+    }
+
+    /// Test context lines when there aren't enough lines after the error.
+    #[test]
+    fn report_terminal_opts_insufficient_context_after() {
+        let code = indoc! { r#"
+          SEC("tp_btf/sched_switch")
+          int handle__sched_switch(u64 *ctx)
+          {
+              bpf_probe_read(event.comm, TASK_COMM_LEN, prev->comm);
+          }
+        "# };
+
+        let m = LintMatch {
+            lint_name: "probe-read".to_string(),
+            message: "bpf_probe_read() is deprecated".to_string(),
+            range: Range {
+                bytes: 68..82,
+                start_point: Point { row: 3, col: 4 },
+                end_point: Point { row: 3, col: 18 },
+            },
+        };
+        let mut report = Vec::new();
+        let () = report_terminal_opts(
+            &m,
+            code.as_bytes(),
+            Path::new("<stdin>"),
+            &mut report,
+            &Opts {
+                extra_lines: Some((1, 5)),
+            },
+        )
+        .unwrap();
+        let report = String::from_utf8(report).unwrap();
+
+        let expected = indoc! { r#"
+            warning: [probe-read] bpf_probe_read() is deprecated
+              --> <stdin>:3:4
+              | 
+            2 | {
+            3 |     bpf_probe_read(event.comm, TASK_COMM_LEN, prev->comm);
+              |     ^^^^^^^^^^^^^^
+            4 | }
+            5 | 
+              | 
+        "# };
+        assert_eq!(report, expected);
+    }
+
+    /// Test Opts default and methods.
+    #[test]
+    fn opts_behavior() {
+        let default_opts = Opts::default();
+        assert_eq!(default_opts.extra_lines, None);
+        assert_eq!(default_opts.lines_before(), 0);
+        assert_eq!(default_opts.lines_after(), 0);
+
+        let extra_opts = Opts {
+            extra_lines: Some((3, 5)),
+        };
+        assert_eq!(extra_opts.lines_before(), 3);
+        assert_eq!(extra_opts.lines_after(), 5);
+    }
+
+    /// Test helper functions for finding context lines.
+    #[test]
+    fn line_start_by_row() {
+        let code = b"line 0\nline 1\nline 2\n";
+        assert_eq!(find_line_start_by_row(code, 0), 0);
+        assert_eq!(find_line_start_by_row(code, 1), 7);
+        assert_eq!(find_line_start_by_row(code, 2), 14);
+        assert_eq!(find_line_start_by_row(code, 10), 0); // Beyond available lines
+    }
+
+    #[test]
+    fn line_counting() {
+        assert_eq!(count_lines(b""), 0);
+        assert_eq!(count_lines(b"single line"), 1);
+        assert_eq!(count_lines(b"line 1\nline 2"), 2);
+        assert_eq!(count_lines(b"line 1\nline 2\n"), 3);
+    }
+
+    #[test]
+    fn context_lines_before() {
+        let code = b"line 0\nline 1\nline 2\nline 3\n";
+
+        // No context requested
+        assert_eq!(find_context_lines_before(code, 2, 0), vec![]);
+
+        // Context from row 0 (should return empty)
+        assert_eq!(find_context_lines_before(code, 0, 2), vec![]);
+
+        // Normal context
+        let result = find_context_lines_before(code, 3, 2);
+        assert_eq!(result, vec![(1, 7), (2, 14)]);
+
+        // More context than available
+        let result = find_context_lines_before(code, 2, 5);
+        assert_eq!(result, vec![(0, 0), (1, 7)]);
+    }
+
+    #[test]
+    fn context_lines_after() {
+        let code = b"line 0\nline 1\nline 2\nline 3\n";
+
+        // No context requested
+        assert_eq!(find_context_lines_after(code, 1, 0), vec![]);
+
+        // Context beyond available lines - asking for 2 lines after row 3, but only row 4 (empty) exists
+        assert_eq!(find_context_lines_after(code, 3, 2), vec![(4, 28)]);
+
+        // Normal context
+        let result = find_context_lines_after(code, 0, 2);
+        assert_eq!(result, vec![(1, 7), (2, 14)]);
+
+        // More context than available - asking for 5 lines after row 2, but only rows 3 and 4 exist
+        let result = find_context_lines_after(code, 2, 5);
+        assert_eq!(result, vec![(3, 21), (4, 28)]);
     }
 }


### PR DESCRIPTION
This PR adds grep-style context line parameters, allowing users to display additional lines of code around lint errors for better context and debugging.

Changes
-------

### New CLI Arguments

*   **`-A, --after <NUM>`**: Show NUM lines after each error line
*   **`-B, --before <NUM>`**: Show NUM lines before each error line
*   **`-C, --context <NUM>`**: Show NUM lines both before and after each error line

*   Added `AdditionalContext` enum to the core library to support configurable context lines
*   Created `report_terminal_opts()` to utilize the new context parameters
*   Kept `report_terminal()` as it was to maintain backwards compatibility and consistent behaviour for current users of bpflint as a library
*   Added helper functions for finding context lines before/after errors with proper boundary handling

### Example Usage

Show 2 lines before and after each error:
`bpflint -C 2 file.bpf.c`

Show 1 line before and 3 lines after each error:
`bpflint -B 1 -A 3 file.bpf.c`

Use maximum values when combined:
`bpflint -C 2 -A 5 file.bpf.c  # Shows 2 before, 5 after`

### Files Modified

*   `cli/src/args.rs`: Added new CLI arguments and context calculation logic
*   `cli/src/main.rs`: Integration with new context parameters
*   `src/lib.rs`: Exported new context types
*   `src/report.rs`: Enhanced reporting with context line support

