### PR TITLE
Fix line number alignment for multi-line matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 - Added `get-current-task` lint
+- Fixed line number alignment for multi-line matches straddling a power
+  of ten boundary in `report_terminal`
 
 
 0.1.2


### PR DESCRIPTION
When a multi-line match is being reported by report_terminal(), the line numbers are not aligned properly if they straddle a power of ten. Fix it by making sure to pad line numbers up correctly in those cases.