### PR TITLE
Lint Recommending bpf_core_cast over bpf_core_read/BPF_CORE_READ

### DIFF
--- a/lints/core-read.scm
+++ b/lints/core-read.scm
@@ -1,0 +1,9 @@
+(call_expression
+    function: (identifier) @function (#eq? @function "bpf_core_read")
+    (#set! "message" "bpf_core_read() is deprecated and replaced by bpf_core_cast(); refer to https://docs.ebpf.io/ebpf-library/libbpf/ebpf/bpf_core_cast/")
+)
+
+(call_expression
+    function: (identifier) @function (#eq? @function "BPF_CORE_READ")
+    (#set! "message" "BPF_CORE_READ() is deprecated and replaced by bpf_core_cast(); refer to https://docs.ebpf.io/ebpf-library/libbpf/ebpf/bpf_core_cast/")
+)


### PR DESCRIPTION
Implemented lint for bpf_core_read and BPF_CORE_READ. New lint recommends switching to bpf_core_cast in both cases. Added calls to both functions in the examples/task_longrun.bpf.c file to ensure all lints get triggered.