### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-Unreleased
-----------
+0.1.3
+-----
 - Added `core-read` lint
 - Added `get-current-task` lint
 - Added `report_terminal_opts` function and `Opts` type

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/d-e-s-o/bpflint"
 
 [package]
 name = "bpflint"
-version = "0.1.2"
+version = "0.1.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
This change bumps the crate's version to 0.1.3. The following notable changes have been made since 0.1.2:
- Added 'core-read' lint
- Added 'get-current-task' lint
- Added report_terminal_opts() function and Opts type
- Fixed line number alignment for multi-line matches straddling a power of ten boundary in report_terminal()