### PR TITLE
cli: Bump version to 0.1.3

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,6 @@
-Unreleased
-----------
-- Added `--after`/`-A`, `--before`/`-B, and `--context`/`-C` arguments
+0.1.3
+-----
+- Added `--after`/`-A`, `--before`/`-B`, and `--context`/`-C` arguments
   to control amount of source code context to show
 
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpflinter"
-version = "0.1.2"
+version = "0.1.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Bump the version of the program to 0.1.3. The following notable changes have been made since 0.1.2:
- Added `--after`/`-A`, `--before`/`-B`, and `--context`/`-C` arguments to control amount of source code context to show