### PR TITLE
Fix indentation of BPF C snippet in library documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,8 @@
 //! ```c
 //! /* bpflint: disable=probe-read */
 //! void handler(void) {
-//!      void *dst = /* ... */
-//!      bpf_probe_read(dst, /* ... */);
+//!     void *dst = /* ... */
+//!     bpf_probe_read(dst, /* ... */);
 //! }
 //! ```
 //!


### PR DESCRIPTION
Indentation by five spaces is...weird. Change it to four.