### PR TITLE
Make lint_custom() publicly accessible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ pub use crate::lint::Lint;
 pub use crate::lint::LintMatch;
 pub use crate::lint::builtin_lints;
 pub use crate::lint::lint;
+pub use crate::lint::lint_custom;
 pub use crate::report::Opts;
 pub use crate::report::report_terminal;
 pub use crate::report::report_terminal_opts;


### PR DESCRIPTION
Make the `lint_custom()` function publicly accessible, so that users can use it. In so doing we pave the way for the creation (and usage) of custom lints, which so far was has not been possible.