### PR TITLE
Add Clone bound to builtin_lints() return type

### DIFF
--- a/src/lint.rs
+++ b/src/lint.rs
@@ -68,7 +68,7 @@ impl AsRef<Lint> for Lint {
 
 
 /// Retrieve the list of lints shipped with the library.
-pub fn builtin_lints() -> impl ExactSizeIterator<Item = Lint> + DoubleEndedIterator {
+pub fn builtin_lints() -> impl ExactSizeIterator<Item = Lint> + DoubleEndedIterator + Clone {
     lints::LINTS.iter().map(|(name, code, message)| Lint {
         name: name.to_string(),
         code: code.to_string(),


### PR DESCRIPTION
Add the `Clone` bound to the return type of the `builtin_lints()` function, to make it possible to clone the returned iterator object.