### PR TITLE
Fix potential panic in report_terminal()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Unreleased
 - Renamed `LintMeta` to `Lint` and made it exhaustive and user
   constructible
   - Added `message` member to it
+- Fixed potential panic of `report_terminal` for matches spanning into
+  the empty last line of a file
 
 
 0.1.3


### PR DESCRIPTION
As it turns out, our `report_terminal()` function may panic when tree-sitter report a somewhat bogus match that captures the newline symbol of the empty last line of a file. That can happen for queries involving the preproc_def definition, for example, which deliberately includes such trailing newlines:

```
  preproc_def: $ => seq(
    preprocessor('define'),
    field('name', $.identifier),
    field('value', optional($.preproc_arg)),
    token.immediate(/\r?\n/),
  ),
```

Because our Lines logic effectively ignores trailing empty lines, we can end up with a panic.
Fix this problem by handling this case more gracefully.