### PR TITLE
Reference more up-to-date bpflinter binary in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ C programs.
        provide statically linked `bpflinter` CLI binaries that can be
        downloaded from each `cli-vX.Y.Z` release and used directly on
        any Linux. E.g.,
-       https://github.com/d-e-s-o/bpflint/releases/download/cli-v0.1.2/bpflinter-x86_64-unknown-linux-musl
+       https://github.com/d-e-s-o/bpflint/releases/download/cli-v0.1.4/bpflinter-x86_64-unknown-linux-musl
 
 #### ❓ **Q: I got a false-positive, what can I do?**
 **A:** Some lints require context that is not possible or feasible for


### PR DESCRIPTION
Reference the `0.1.4` `bpflinter` binary in the `README` instead of the somewhat dated `0.1.2`, to nudge users towards the latest and greatest.