### PR TITLE
Add support for highlighting code in output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ pretty_assertions = "1.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tree-sitter = "0.25"
+tree-sitter-highlight = "0.25.10"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tree-sitter = { package = "tree-sitter-c2rust", version = "0.25" }

--- a/cli/USAGE.md
+++ b/cli/USAGE.md
@@ -19,6 +19,9 @@ Options:
   -C, --context <CONTEXT>
           Number of lines to show before and after the lint match
 
+      --color
+          Print in color
+
       --print-lints
           Print a list of available lints
 

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -74,6 +74,9 @@ pub struct Args {
     /// Number of lines to show before and after the lint match.
     #[arg(short = 'C', long = "context", value_parser = parse_context_line_count, conflicts_with_all = ["before", "after"])]
     pub context: Option<u8>,
+    /// Print in color
+    #[arg(long = "color", default_value_t = false)]
+    pub color: bool,
     /// Print a list of available lints.
     #[arg(long, exclusive = true)]
     pub print_lints: bool,
@@ -85,7 +88,10 @@ pub struct Args {
 impl Args {
     /// Calculate the effective context configuration.
     pub fn additional_options(&self) -> bpflint::Opts {
-        let mut opts = bpflint::Opts::default();
+        let mut opts = bpflint::Opts {
+            color: self.color,
+            ..Default::default()
+        };
         if let Some(before) = self.before.or(self.context) {
             opts.extra_lines.0 = before;
         }

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -1,0 +1,146 @@
+use anyhow::Result;
+
+pub(crate) trait Highlighter {
+    fn highlight(&self, code: &[u8]) -> Result<String>;
+}
+
+struct NopHighlighter;
+impl Highlighter for NopHighlighter {
+    fn highlight(&self, code: &[u8]) -> Result<String> {
+        Ok(String::from_utf8_lossy(code).to_string())
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod imp {
+    use super::Highlighter;
+    use anyhow::Result;
+    use tree_sitter_highlight::Highlight;
+    use tree_sitter_highlight::HighlightConfiguration;
+    use tree_sitter_highlight::HighlightEvent;
+
+    use super::NopHighlighter;
+
+    struct TreeSitterHighlighter {
+        highlight_config: tree_sitter_highlight::HighlightConfiguration,
+    }
+
+    impl TreeSitterHighlighter {
+        pub fn new() -> Result<Self> {
+            let c_language = tree_sitter_bpf_c::LANGUAGE.into();
+            let mut highlight_config = tree_sitter_highlight::HighlightConfiguration::new(
+                c_language,
+                "bpf-c",
+                tree_sitter_bpf_c::HIGHLIGHTS_QUERY,
+                "",
+                "",
+            )?;
+            highlight_config.configure(
+                &ANSI_HIGHLIGHT_ARRAY
+                    .iter()
+                    .map(|(name, _)| *name)
+                    .collect::<Vec<&str>>(),
+            );
+            Ok(Self { highlight_config })
+        }
+    }
+
+    impl Highlighter for TreeSitterHighlighter {
+        fn highlight(&self, code: &[u8]) -> anyhow::Result<String> {
+            let mut highlighter = tree_sitter_highlight::Highlighter::new();
+            let highlights = highlighter.highlight(&self.highlight_config, code, None, |_| None)?;
+            let mut result = String::new();
+            for event in highlights {
+                match event.unwrap() {
+                    HighlightEvent::Source { start, end } => {
+                        result.push_str(&String::from_utf8_lossy(&code[start..end]));
+                    },
+                    HighlightEvent::HighlightStart(s) => {
+                        result.push_str(&ansi_for_highlight(s, &self.highlight_config));
+                    },
+                    HighlightEvent::HighlightEnd => {
+                        result.push_str(AnsiColor24::reset());
+                    },
+                }
+            }
+            Ok(result)
+        }
+    }
+
+    pub fn create_highlighter(color: bool) -> Result<Box<dyn Highlighter>> {
+        if !color {
+            return Ok(Box::new(NopHighlighter));
+        }
+
+        TreeSitterHighlighter::new().map(|h| Box::new(h) as Box<dyn Highlighter>)
+    }
+
+    /// Represents a 24-bit (true color) ANSI color.
+    /// Usage: emits \x1b[38;2;R;G;Bm for foreground color.
+    #[derive(Copy, Clone, Debug)]
+    struct AnsiColor24(pub u8, pub u8, pub u8);
+    impl AnsiColor24 {
+        /// Returns the ANSI escape code for this color (24-bit/true color).
+        pub fn as_ansi_fg(&self) -> String {
+            format!("\x1b[38;2;{};{};{}m", self.0, self.1, self.2)
+        }
+        /// Returns the ANSI reset code.
+        pub fn reset() -> &'static str {
+            "\x1b[0m"
+        }
+    }
+
+    const GITHUB_PURPLE: AnsiColor24 = AnsiColor24(121, 93, 163); // #795da3
+    const GITHUB_TEAL: AnsiColor24 = AnsiColor24(0, 134, 179); // #0086B3
+    const GITHUB_PINK: AnsiColor24 = AnsiColor24(167, 29, 93); // #a71d5d
+    const GITHUB_BLUE: AnsiColor24 = AnsiColor24(24, 54, 145); // #183691
+    const GITHUB_GRAY: AnsiColor24 = AnsiColor24(150, 152, 150); // #969896
+    const GITHUB_DARKGRAY: AnsiColor24 = AnsiColor24(51, 51, 51); // #333333
+
+    /// Syntax highlight mapping for GitHub Sublime theme (24-bit colors)
+    /// <https://github.com/AlexanderEkdahl/github-sublime-theme/blob/master/GitHub.tmTheme>
+    static ANSI_HIGHLIGHT_ARRAY: [(&str, AnsiColor24); 15] = [
+        ("function", GITHUB_PURPLE),
+        ("function.builtin", GITHUB_TEAL),
+        ("keyword", GITHUB_PINK),
+        ("string", GITHUB_BLUE),
+        ("comment", GITHUB_GRAY),
+        ("type", GITHUB_PINK),
+        ("constant", GITHUB_TEAL),
+        ("variable", GITHUB_TEAL),
+        ("number", GITHUB_TEAL),
+        ("operator", GITHUB_PINK),
+        ("attribute", GITHUB_PURPLE),
+        ("property", GITHUB_TEAL),
+        ("punctuation", GITHUB_DARKGRAY),
+        ("macro", GITHUB_TEAL),
+        ("namespace", GITHUB_DARKGRAY),
+    ];
+    /// A map of highlight group names to their corresponding ANSI color codes.
+    ///
+    /// If a highlight group name is not found in the map, it will return the ANSI color
+    /// code reset.
+    fn ansi_for_highlight(h: Highlight, highlight_config: &HighlightConfiguration) -> String {
+        let group_name = *highlight_config.names().get(h.0).unwrap_or(&"unknown");
+        ANSI_HIGHLIGHT_ARRAY
+            .iter()
+            .find(|(name, _)| *name == group_name)
+            .map(|(_, color)| color.as_ansi_fg())
+            .unwrap_or(AnsiColor24::reset().to_string())
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod imp {
+    use super::Highlighter;
+    use super::NopHighlighter;
+    use anyhow::Result;
+
+    pub fn create_highlighter(_color: bool) -> Result<Box<dyn Highlighter>> {
+        // No-op highlighter for wasm
+        return Ok(Box::new(NopHighlighter))
+    }
+}
+
+// Re-export for use in your main code
+pub use imp::create_highlighter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 #[macro_use]
 mod redefine;
 
+mod highlight;
 mod lines;
 mod lint;
 mod report;

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -16,7 +16,9 @@ where
     let () = lint(code.as_ref())
         .unwrap()
         .into_iter()
-        .try_for_each(|m| report_terminal(&m, code.as_ref(), Path::new("<stdin>"), &mut report))
+        .try_for_each(|m| {
+            report_terminal(&m, code.as_ref(), Path::new("<stdin>"), false, &mut report)
+        })
         .unwrap();
     let report = String::from_utf8(report).unwrap();
     report


### PR DESCRIPTION
This introduces the ability to highlight queries in the output of the CLI

**Remaining**
- [x] Add support for CLI flag to disable/enable color. Maybe "auto" for detecting tty?
- [x] Extend bpf grammar so that we don't use the C grammar.
- [x] Disable coloring for tests so we don't have to update them. 
- [x] Change to 24bit color.
- [x] wasm builds
- [x] add fancy Rust trait

**Open Questions**
1. Do we want any themeing? I'm not sure how to do that or if there is a tree-sitter framework for that.
2. Should we land this with the C grammar first?
3. Should we just pick "a theme" to start? Dracula? Cappaccino?

<img width="1905" height="925" alt="image" src="https://github.com/user-attachments/assets/7e1e6647-4230-4891-9e97-fb38229b57eb" />

fixes #2